### PR TITLE
Migrate Neovim config to lazy.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,73 @@
 # nvim
 
-## Instructions
+Modern Neovim configuration using lazy.nvim
 
-1. Install iTerm
-2. clone repo
-3. Install SFMono Nerd Font
-4. Apply iTerm preferences saved in repo
-  - Set preferences from file but don't save
-  - Quit and reopen
-5. `brew install neovim`
-6. `brew install fd`
-7. `brew install the_silver_searcher`
-8. Add `source $HOME/{directory}/nvim/init.vim` to `~/.config/nvim/init.vim`
-9. `:PlugInstall`
-10. Install Karabiner
-11. Symlink Karabiner preferences: `ln -s ~/{directory}/nvim/karabiner ~/.config`
-12. Restart Karabiner:`launchctl kickstart -k gui/`id -u`/org.pqrs.karabiner.karabiner_console_user_server`
-13. Safari sVimrc gist id: `3e0411beaf6f78c3bec04dbeb0e0bf85`
-14. Safari sVimcss gist id: `3290e93863886572db5b2305c80227f8`
+## Quick Start
 
-## Aliases
+1. Install Neovim (0.9+):
+   ```bash
+   # macOS
+   brew install neovim
 
-`alias v="nvim"`
-`alias vim="nvim"`
+   # Ubuntu/Debian
+   sudo apt install neovim
+   ```
+
+2. Install dependencies:
+   ```bash
+   # macOS
+   brew install ripgrep fd
+
+   # Ubuntu/Debian
+   sudo apt install ripgrep fd-find
+   ```
+
+3. Clone and set up config:
+   ```bash
+   git clone https://github.com/mrangelmarino/nvim.git
+   ln -s ~/nvim/init.lua ~/.config/nvim/init.lua
+   ```
+
+4. Launch Neovim - plugins install automatically:
+   ```bash
+   nvim
+   ```
+
+## Plugins
+
+| Plugin | Purpose |
+|--------|---------|
+| lazy.nvim | Package manager |
+| nvim-tree | File explorer |
+| telescope | Fuzzy finder |
+| nvim-surround | Surround commands (cs/ds/ys) |
+| Comment.nvim | Commenting |
+| nvim-treesitter | Syntax highlighting |
+| lualine | Status bar |
+| gitsigns | Git gutter |
+| tokyonight | Color theme |
+| nvim-autopairs | Auto brackets |
+| vim-fugitive | Git integration |
 
 ## Keyboard Shortcuts
+
+Leader key: `;`
 
 ### Navigation
 | Shortcut | Description |
 |----------|-------------|
-| `\|` or `;n` | Toggle file explorer (NERDTree) |
+| `\|` or `;n` | Toggle file explorer |
 | `Shift + k` | Next buffer |
 | `Shift + j` | Previous buffer |
 | `Shift + h` | Move to left window |
 | `Shift + l` | Move to right window |
+| `j` / `k` | Move by visual line |
 
-### File Finding
+### Finding
 | Shortcut | Description |
 |----------|-------------|
 | `;f` | Fuzzy find files |
-| `;a` | Search in files (requires Ag/Silver Searcher) |
+| `;a` | Live grep (search in files) |
 | `;b` | List/search buffers |
 
 ### Editing
@@ -47,38 +75,47 @@
 |----------|-------------|
 | `cs{(` | Change surrounding {} to () |
 | `ds{` | Delete surrounding {} |
-| `yss{` | Add {} around line |
-| `cp` | Copy to system clipboard |
-| `cv` | Paste from system clipboard |
-| `Space` | Add blank line before cursor |
-| `Enter` | Add blank line after cursor |
+| `ys{motion}{char}` | Add surrounding |
+| `Space` | Add blank line above |
+| `Enter` | Add blank line below |
 | `;r` | Redo |
-| Double-click | Highlight all occurrences of word |
-| `Esc Esc` | Clear search highlighting |
+| `Esc Esc` | Clear search highlight |
+| Double-click | Highlight all occurrences |
 
 ### Comments
 | Shortcut | Description |
 |----------|-------------|
-| `;cc` | Comment out line(s) |
-| `;cu` | Uncomment line(s) |
+| `;cc` | Toggle comment line |
+| `;cb` | Toggle block comment |
 
-### Buffer Management
-| Command | Description |
-|---------|-------------|
-| `:BO` | Close all buffers except current one |
-| `:BD` | Delete current buffer |
+## Settings
 
-### Other Useful Commands
-| Command | Description |
-|---------|-------------|
-| `:Guides` | Toggle indent guides |
-| `:Files` | Fuzzy file finder |
-| `:Ag` | Search in files |
-| `:Buffers` | List buffers |
+- 2-space indentation (spaces, not tabs)
+- Line numbers enabled
+- Mouse enabled
+- Smart case search
+- Persistent undo
+- Color column at 100
+- Auto-strip trailing whitespace
+- True color support
 
-> Note: The `;` key is configured as the leader key. For shortcuts starting with `;`, press the semicolon first, then the following key.
+## Aliases (add to shell config)
 
-### Windows Setup Requirements
-- For `;a` (Ag search): Install [Silver Searcher](https://github.com/ggreer/the_silver_searcher)
-- For optimal fuzzy finding: Install [fd](https://github.com/sharkdp/fd)
-- For system clipboard integration: Ensure proper clipboard support is configured
+```bash
+alias v="nvim"
+alias vim="nvim"
+```
+
+## iTerm & Karabiner (optional)
+
+For the full terminal experience on macOS:
+1. Install SFMono Nerd Font (included in repo)
+2. Import iTerm preferences: `com.googlecode.iterm2.plist`
+3. Install Karabiner and symlink config:
+   ```bash
+   ln -s ~/nvim/karabiner ~/.config/karabiner
+   ```
+
+## Legacy
+
+The old vim-plug configuration is preserved in `init.vim` for reference.

--- a/init.lua
+++ b/init.lua
@@ -104,32 +104,26 @@ require("lazy").setup({
   {
     "nvim-treesitter/nvim-treesitter",
     build = ":TSUpdate",
-    config = function()
-      require("nvim-treesitter.configs").setup({
-        ensure_installed = {
-          "lua",
-          "vim",
-          "vimdoc",
-          "javascript",
-          "typescript",
-          "tsx",
-          "json",
-          "html",
-          "css",
-          "markdown",
-          "bash",
-          "python",
-        },
-        sync_install = false,
-        auto_install = true,
-        highlight = {
-          enable = true,
-        },
-        indent = {
-          enable = true,
-        },
-      })
-    end,
+    main = "nvim-treesitter",
+    opts = {
+      ensure_installed = {
+        "lua",
+        "vim",
+        "vimdoc",
+        "javascript",
+        "typescript",
+        "tsx",
+        "json",
+        "html",
+        "css",
+        "markdown",
+        "bash",
+        "python",
+      },
+      auto_install = true,
+      highlight = { enable = true },
+      indent = { enable = true },
+    },
   },
 
   -- Status line (replaces airline)

--- a/init.lua
+++ b/init.lua
@@ -1,0 +1,343 @@
+--------------------------------------------------------------------------------
+-- Neovim Configuration with lazy.nvim
+--------------------------------------------------------------------------------
+
+-- Leader key (must be set before lazy.nvim)
+vim.g.mapleader = ";"
+vim.g.maplocalleader = ";"
+
+--------------------------------------------------------------------------------
+-- Bootstrap lazy.nvim
+--------------------------------------------------------------------------------
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not vim.loop.fs_stat(lazypath) then
+  vim.fn.system({
+    "git",
+    "clone",
+    "--filter=blob:none",
+    "https://github.com/folke/lazy.nvim.git",
+    "--branch=stable",
+    lazypath,
+  })
+end
+vim.opt.rtp:prepend(lazypath)
+
+--------------------------------------------------------------------------------
+-- Plugins
+--------------------------------------------------------------------------------
+require("lazy").setup({
+  -- File explorer (replaces NERDTree)
+  {
+    "nvim-tree/nvim-tree.lua",
+    dependencies = { "nvim-tree/nvim-web-devicons" },
+    config = function()
+      require("nvim-tree").setup({
+        view = {
+          width = 30,
+        },
+        renderer = {
+          icons = {
+            show = {
+              file = true,
+              folder = true,
+              folder_arrow = true,
+              git = true,
+            },
+          },
+        },
+        filters = {
+          dotfiles = false,
+        },
+      })
+    end,
+  },
+
+  -- Fuzzy finder (replaces fzf.vim)
+  {
+    "nvim-telescope/telescope.nvim",
+    tag = "0.1.8",
+    dependencies = { "nvim-lua/plenary.nvim" },
+    config = function()
+      require("telescope").setup({
+        defaults = {
+          file_ignore_patterns = { ".git/" },
+        },
+        pickers = {
+          find_files = {
+            hidden = true,
+          },
+        },
+      })
+    end,
+  },
+
+  -- Surround commands (cs/ds/ys)
+  {
+    "kylechui/nvim-surround",
+    version = "*",
+    event = "VeryLazy",
+    config = function()
+      require("nvim-surround").setup({})
+    end,
+  },
+
+  -- Commenting (replaces nerdcommenter)
+  {
+    "numToStr/Comment.nvim",
+    config = function()
+      require("Comment").setup({
+        padding = true,
+        sticky = true,
+        toggler = {
+          line = "<leader>cc",
+          block = "<leader>cb",
+        },
+        opleader = {
+          line = "<leader>c",
+          block = "<leader>b",
+        },
+      })
+    end,
+  },
+
+  -- Treesitter (syntax highlighting)
+  {
+    "nvim-treesitter/nvim-treesitter",
+    build = ":TSUpdate",
+    config = function()
+      require("nvim-treesitter.configs").setup({
+        ensure_installed = {
+          "lua",
+          "vim",
+          "vimdoc",
+          "javascript",
+          "typescript",
+          "tsx",
+          "json",
+          "html",
+          "css",
+          "markdown",
+          "bash",
+          "python",
+        },
+        sync_install = false,
+        auto_install = true,
+        highlight = {
+          enable = true,
+        },
+        indent = {
+          enable = true,
+        },
+      })
+    end,
+  },
+
+  -- Status line (replaces airline)
+  {
+    "nvim-lualine/lualine.nvim",
+    dependencies = { "nvim-tree/nvim-web-devicons" },
+    config = function()
+      require("lualine").setup({
+        options = {
+          theme = "tokyonight",
+          section_separators = "",
+          component_separators = "",
+        },
+        sections = {
+          lualine_a = { "mode" },
+          lualine_b = { "branch", "diff", "diagnostics" },
+          lualine_c = { "filename" },
+          lualine_x = { "encoding", "fileformat", "filetype" },
+          lualine_y = { "progress" },
+          lualine_z = { "location" },
+        },
+        tabline = {
+          lualine_a = { "buffers" },
+          lualine_z = { "tabs" },
+        },
+      })
+    end,
+  },
+
+  -- Git signs (replaces gitgutter)
+  {
+    "lewis6991/gitsigns.nvim",
+    config = function()
+      require("gitsigns").setup({
+        signs = {
+          add = { text = "+" },
+          change = { text = "~" },
+          delete = { text = "_" },
+          topdelete = { text = "‾" },
+          changedelete = { text = "~" },
+        },
+      })
+    end,
+  },
+
+  -- Theme (tokyonight, similar dark feel to quantum)
+  {
+    "folke/tokyonight.nvim",
+    lazy = false,
+    priority = 1000,
+    config = function()
+      require("tokyonight").setup({
+        style = "night",
+        transparent = false,
+        terminal_colors = true,
+        styles = {
+          comments = { italic = true },
+          keywords = { italic = true },
+        },
+      })
+      vim.cmd.colorscheme("tokyonight-night")
+    end,
+  },
+
+  -- Auto pairs
+  {
+    "windwp/nvim-autopairs",
+    event = "InsertEnter",
+    config = function()
+      require("nvim-autopairs").setup({})
+    end,
+  },
+
+  -- Git integration
+  { "tpope/vim-fugitive" },
+})
+
+--------------------------------------------------------------------------------
+-- Editor Settings
+--------------------------------------------------------------------------------
+local opt = vim.opt
+
+-- Indentation (2-space, spaces not tabs)
+opt.shiftwidth = 2
+opt.softtabstop = 2
+opt.tabstop = 2
+opt.expandtab = true
+opt.smartindent = true
+opt.autoindent = true
+
+-- Line numbers
+opt.number = true
+
+-- Mouse enabled
+opt.mouse = "a"
+
+-- Search
+opt.smartcase = true
+opt.ignorecase = true
+opt.gdefault = true
+
+-- Persistent undo
+opt.undofile = true
+opt.undodir = vim.fn.expand("~/.config/nvim/backups")
+vim.fn.mkdir(vim.fn.expand("~/.config/nvim/backups"), "p")
+
+-- Color column at 100
+opt.colorcolumn = "100"
+
+-- Enable termguicolors
+opt.termguicolors = true
+
+-- Other appearance settings
+opt.cursorline = true
+opt.showmatch = true
+opt.wrap = true
+opt.linebreak = true
+opt.showmode = false
+opt.list = true
+opt.listchars = { tab = "│·", trail = "·", extends = "→" }
+
+-- Buffer/window behavior
+opt.hidden = true
+opt.pumheight = 30
+opt.history = 500
+opt.encoding = "utf-8"
+opt.fileencoding = "utf-8"
+
+-- Folding (disabled by default like original)
+opt.foldmethod = "indent"
+opt.foldenable = false
+opt.foldlevelstart = 99
+
+--------------------------------------------------------------------------------
+-- Keybindings
+--------------------------------------------------------------------------------
+local keymap = vim.keymap.set
+local opts = { noremap = true, silent = true }
+
+-- File tree toggle: | or ;n
+keymap("n", "|", ":NvimTreeToggle<CR>", opts)
+keymap("n", "<Leader>n", ":NvimTreeToggle<CR>", opts)
+
+-- Buffer navigation: Shift+j/k
+keymap("n", "<S-k>", ":bnext<CR>", opts)
+keymap("n", "<S-j>", ":bprevious<CR>", opts)
+
+-- Window navigation: Shift+h/l
+keymap("n", "<S-h>", "<C-w>h", opts)
+keymap("n", "<S-l>", "<C-w>l", opts)
+
+-- Telescope: fuzzy find, grep, buffers
+keymap("n", "<Leader>f", ":Telescope find_files<CR>", opts)
+keymap("n", "<Leader>a", ":Telescope live_grep<CR>", opts)
+keymap("n", "<Leader>b", ":Telescope buffers<CR>", opts)
+
+-- Redo
+keymap("n", "<Leader>r", "<C-r>", opts)
+
+-- Clear search highlight: Esc Esc
+keymap("n", "<Esc><Esc>", ":noh<CR>", opts)
+
+-- Insert blank line above (Space)
+keymap("n", "<Space>", "moO<Esc>`ok", opts)
+
+-- Insert blank line below (Enter)
+keymap("n", "<CR>", "moo<Esc>`oj", opts)
+
+-- Move by visual line (gj/gk)
+keymap("n", "j", "gj", opts)
+keymap("n", "k", "gk", opts)
+keymap("v", "j", "gj", opts)
+keymap("v", "k", "gk", opts)
+keymap("n", "<Down>", "gj", opts)
+keymap("n", "<Up>", "gk", opts)
+keymap("v", "<Down>", "gj", opts)
+keymap("v", "<Up>", "gk", opts)
+keymap("i", "<Down>", "<C-o>gj", opts)
+keymap("i", "<Up>", "<C-o>gk", opts)
+
+-- Highlight occurrences on double click
+keymap("n", "<2-LeftMouse>", "*", opts)
+
+--------------------------------------------------------------------------------
+-- Autocommands
+--------------------------------------------------------------------------------
+local augroup = vim.api.nvim_create_augroup
+local autocmd = vim.api.nvim_create_autocmd
+
+-- Strip trailing whitespace on save
+augroup("TrimWhitespace", { clear = true })
+autocmd("BufWritePre", {
+  group = "TrimWhitespace",
+  pattern = "*",
+  callback = function()
+    local save_cursor = vim.fn.getpos(".")
+    vim.cmd([[%s/\s\+$//e]])
+    vim.fn.setpos(".", save_cursor)
+  end,
+})
+
+-- Open nvim-tree on startup if no file specified
+augroup("NvimTreeAutoOpen", { clear = true })
+autocmd("VimEnter", {
+  group = "NvimTreeAutoOpen",
+  callback = function()
+    if vim.fn.argc() == 0 then
+      require("nvim-tree.api").tree.open()
+    end
+  end,
+})


### PR DESCRIPTION
Replace vim-plug with lazy.nvim package manager and update plugins:
- nvim-tree replaces NERDTree
- telescope replaces fzf.vim
- nvim-surround replaces vim-surround
- Comment.nvim replaces nerdcommenter
- nvim-treesitter replaces per-language syntax plugins
- lualine replaces airline
- gitsigns replaces gitgutter
- tokyonight theme replaces quantum

All keybindings preserved (;f, ;a, ;b, |, Shift+j/k, etc.)