### PR TITLE
Migrate neovim config from vim-plug to lazy.nvim

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -313,15 +313,17 @@ keymap("n", "<2-LeftMouse>", "*", opts)
 local augroup = vim.api.nvim_create_augroup
 local autocmd = vim.api.nvim_create_autocmd
 
--- Strip trailing whitespace on save
+-- Strip trailing whitespace on save (only for modifiable buffers)
 augroup("TrimWhitespace", { clear = true })
 autocmd("BufWritePre", {
   group = "TrimWhitespace",
   pattern = "*",
   callback = function()
-    local save_cursor = vim.fn.getpos(".")
-    vim.cmd([[%s/\s\+$//e]])
-    vim.fn.setpos(".", save_cursor)
+    if vim.bo.modifiable then
+      local save_cursor = vim.fn.getpos(".")
+      vim.cmd([[%s/\s\+$//e]])
+      vim.fn.setpos(".", save_cursor)
+    end
   end,
 })
 


### PR DESCRIPTION
Summary:

Replace vim-plug with lazy.nvim package manager
Modernize plugins (nvim-tree, telescope, treesitter, lualine, gitsigns)
Preserve all existing keybindings
Add tokyonight theme
Fix whitespace trimming for non-modifiable buffers
The branch has 2 commits ready to merge.