### PR TITLE
Migrate neovim config from vim-plug to lazy.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,34 +4,31 @@ Modern Neovim configuration using lazy.nvim
 
 ## Quick Start
 
-1. Install Neovim (0.9+):
-   ```bash
-   # macOS
-   brew install neovim
+```bash
+git clone https://github.com/mrangelmarino/nvim.git ~/nvim
+cd ~/nvim && ./install.sh
+nvim
+```
 
-   # Ubuntu/Debian
-   sudo apt install neovim
-   ```
+The install script handles dependencies (neovim, ripgrep, fd) and symlinks the config.
 
-2. Install dependencies:
-   ```bash
-   # macOS
-   brew install ripgrep fd
+### Manual Install
 
-   # Ubuntu/Debian
-   sudo apt install ripgrep fd-find
-   ```
+If you prefer manual setup:
 
-3. Clone and set up config:
-   ```bash
-   git clone https://github.com/mrangelmarino/nvim.git
-   ln -s ~/nvim/init.lua ~/.config/nvim/init.lua
-   ```
+```bash
+# Install dependencies
+brew install neovim ripgrep fd   # macOS
+# or: sudo apt install neovim ripgrep fd-find   # Debian/Ubuntu
 
-4. Launch Neovim - plugins install automatically:
-   ```bash
-   nvim
-   ```
+# Clone and symlink
+git clone https://github.com/mrangelmarino/nvim.git ~/nvim
+mkdir -p ~/.config/nvim
+ln -sf ~/nvim/init.lua ~/.config/nvim/init.lua
+
+# Launch (plugins install automatically)
+nvim
+```
 
 ## Plugins
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ Leader key: `;`
 - Auto-strip trailing whitespace
 - True color support
 
+## Uninstall
+
+```bash
+cd ~/nvim && ./uninstall.sh
+```
+
+Removes symlinks and optionally cleans up plugin data and undo history.
+
 ## Aliases (add to shell config)
 
 ```bash

--- a/init.lua
+++ b/init.lua
@@ -31,7 +31,17 @@ require("lazy").setup({
     "nvim-tree/nvim-tree.lua",
     dependencies = { "nvim-tree/nvim-web-devicons" },
     config = function()
+      local function on_attach(bufnr)
+        local api = require("nvim-tree.api")
+        -- Apply default mappings
+        api.config.mappings.default_on_attach(bufnr)
+        -- Add window navigation (Shift+h/l) to work in nvim-tree
+        local opts = { buffer = bufnr, noremap = true, silent = true }
+        vim.keymap.set("n", "<S-h>", "<C-w>h", opts)
+        vim.keymap.set("n", "<S-l>", "<C-w>l", opts)
+      end
       require("nvim-tree").setup({
+        on_attach = on_attach,
         view = {
           width = 30,
         },
@@ -55,7 +65,7 @@ require("lazy").setup({
   -- Fuzzy finder (replaces fzf.vim)
   {
     "nvim-telescope/telescope.nvim",
-    tag = "0.1.8",
+    branch = "master",
     dependencies = { "nvim-lua/plenary.nvim" },
     config = function()
       require("telescope").setup({
@@ -84,6 +94,7 @@ require("lazy").setup({
   -- Commenting (replaces nerdcommenter)
   {
     "numToStr/Comment.nvim",
+    lazy = false,
     config = function()
       require("Comment").setup({
         padding = true,
@@ -199,6 +210,11 @@ require("lazy").setup({
 
   -- Git integration
   { "tpope/vim-fugitive" },
+}, {
+  -- Lazy.nvim options
+  checker = { enabled = false },           -- Don't auto-check for updates
+  change_detection = { enabled = false },  -- Don't auto-reload config
+  install = { colorscheme = { "tokyonight" } },
 })
 
 --------------------------------------------------------------------------------
@@ -250,7 +266,7 @@ opt.hidden = true
 opt.pumheight = 30
 opt.history = 500
 opt.encoding = "utf-8"
-opt.fileencoding = "utf-8"
+-- Note: fileencoding is buffer-local, set via autocommand or leave as default (utf-8)
 
 -- Folding (disabled by default like original)
 opt.foldmethod = "indent"
@@ -282,6 +298,10 @@ keymap("n", "<Leader>b", ":Telescope buffers<CR>", opts)
 
 -- Redo
 keymap("n", "<Leader>r", "<C-r>", opts)
+
+-- Delete line in normal mode (BS = Mac "delete" key, Del = forward delete)
+keymap("n", "<BS>", "dd", opts)
+keymap("n", "<Del>", "dd", opts)
 
 -- Clear search highlight: Esc Esc
 keymap("n", "<Esc><Esc>", ":noh<CR>", opts)

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+
+echo "Installing neovim config..."
+
+# Detect OS
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  OS="macos"
+elif [[ -f /etc/debian_version ]]; then
+  OS="debian"
+else
+  OS="unknown"
+fi
+
+# Install dependencies
+echo "Installing dependencies..."
+if [[ "$OS" == "macos" ]]; then
+  if ! command -v brew &> /dev/null; then
+    echo "Homebrew not found. Install from https://brew.sh"
+    exit 1
+  fi
+  brew install neovim ripgrep fd
+elif [[ "$OS" == "debian" ]]; then
+  sudo apt update
+  sudo apt install -y neovim ripgrep fd-find
+else
+  echo "Unknown OS. Please install manually: neovim, ripgrep, fd"
+fi
+
+# Backup existing config
+if [[ -e ~/.config/nvim/init.lua ]] || [[ -e ~/.config/nvim/init.vim ]]; then
+  echo "Backing up existing config to ~/.config/nvim.bak"
+  mv ~/.config/nvim ~/.config/nvim.bak
+fi
+
+# Create config directory
+mkdir -p ~/.config/nvim
+
+# Get script directory (where repo is cloned)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Symlink init.lua
+ln -sf "$SCRIPT_DIR/init.lua" ~/.config/nvim/init.lua
+
+echo ""
+echo "Done! Run 'nvim' to complete plugin installation."
+echo ""
+echo "Optional: Add these aliases to your shell config:"
+echo '  alias v="nvim"'
+echo '  alias vim="nvim"'

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+echo "Uninstalling neovim config..."
+
+# Remove symlink
+if [[ -L ~/.config/nvim/init.lua ]]; then
+  rm ~/.config/nvim/init.lua
+  echo "Removed ~/.config/nvim/init.lua symlink"
+fi
+
+# Remove empty nvim config dir
+if [[ -d ~/.config/nvim ]] && [[ -z "$(ls -A ~/.config/nvim)" ]]; then
+  rmdir ~/.config/nvim
+  echo "Removed empty ~/.config/nvim directory"
+fi
+
+# Ask about plugin data
+read -p "Remove lazy.nvim plugin data (~/.local/share/nvim)? [y/N] " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+  rm -rf ~/.local/share/nvim
+  echo "Removed plugin data"
+fi
+
+# Ask about undo history
+read -p "Remove persistent undo history (~/.config/nvim/backups)? [y/N] " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+  rm -rf ~/.config/nvim/backups
+  echo "Removed undo history"
+fi
+
+# Restore backup if exists
+if [[ -d ~/.config/nvim.bak ]]; then
+  read -p "Restore previous config from ~/.config/nvim.bak? [y/N] " -n 1 -r
+  echo
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    mv ~/.config/nvim.bak ~/.config/nvim
+    echo "Restored previous config"
+  fi
+fi
+
+echo "Done!"


### PR DESCRIPTION
## Summary
Modernize neovim configuration with lazy.nvim and contemporary plugins while preserving all existing keybindings.

### Changes
- Replace vim-plug with lazy.nvim package manager
- Modernize plugins:
  - nvim-tree (replaces NERDTree)
  - telescope (replaces fzf.vim)
  - nvim-treesitter (replaces per-language syntax plugins)
  - lualine (replaces airline)
  - gitsigns (replaces gitgutter)
  - Comment.nvim (replaces nerdcommenter)
  - nvim-surround (replaces vim-surround)
  - tokyonight theme (replaces quantum)
- Add install.sh for one-command setup
- Add uninstall.sh for clean removal
- Update README with new instructions

### Keybindings preserved
All original keybindings work unchanged: `;f`, `;a`, `;b`, `|`, `Shift+j/k`, `Shift+h/l`, `;cc`, `;r`, `Space`, `Enter`, `Esc Esc`

## Test plan
- [ ] Run `./install.sh` on macOS or Linux
- [ ] Launch `nvim` and verify plugins install
- [ ] Test keybindings
- [ ] Run `./uninstall.sh` to verify clean removal
